### PR TITLE
Fix typo in sort_merge comment

### DIFF
--- a/sort_merge.pl
+++ b/sort_merge.pl
@@ -27,7 +27,7 @@ while(<DATA>){
 	#get serial from each line
 	my ($seq,$min,$max, $sign, $serial, $name) = split(/\s+/);
 
-	#in Python ,use in  for convince
+	#in Python ,use in  for convenience
 	unless (grep $_->[2] eq $serial ,@name_array){
 		push  @name_array, [$seq,$sign,$serial,$name];
 	} ;


### PR DESCRIPTION
## Summary
- fix typo in sort_merge.pl comment (convince -> convenience)

## Testing
- `perl -c sort_merge.pl`
- `perl sort_merge.pl`

------
https://chatgpt.com/codex/tasks/task_e_68994a9baaf0833086b55cf630bd3c9a